### PR TITLE
ci: finalize sdk live integration lane and fixture workflow

### DIFF
--- a/.github/workflows/sdk_live_integration.yml
+++ b/.github/workflows/sdk_live_integration.yml
@@ -8,11 +8,13 @@ on:
         required: false
         default: false
         type: boolean
-  schedule:
-    - cron: "55 7 * * *"
 
 permissions:
   contents: read
+
+concurrency:
+  group: sdk-live-integration-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   live-integration:
@@ -26,6 +28,12 @@ jobs:
       QUERYLAKE_LIVE_TEST_COLLECTION_ID: ${{ vars.QUERYLAKE_LIVE_TEST_COLLECTION_ID }}
       QUERYLAKE_LIVE_TEST_QUERY: ${{ vars.QUERYLAKE_LIVE_TEST_QUERY }}
       QUERYLAKE_LIVE_ALLOW_NON_STAGING: ${{ vars.QUERYLAKE_LIVE_ALLOW_NON_STAGING }}
+      QUERYLAKE_LIVE_TIMEOUT_SECONDS: ${{ vars.QUERYLAKE_LIVE_TIMEOUT_SECONDS }}
+      QUERYLAKE_LIVE_RETRY_ATTEMPTS: ${{ vars.QUERYLAKE_LIVE_RETRY_ATTEMPTS }}
+      QUERYLAKE_LIVE_RETRY_DELAY_SECONDS: ${{ vars.QUERYLAKE_LIVE_RETRY_DELAY_SECONDS }}
+      QUERYLAKE_LIVE_STRICT_EXPECTATIONS: ${{ vars.QUERYLAKE_LIVE_STRICT_EXPECTATIONS }}
+      QUERYLAKE_LIVE_QUERY_CASES_PATH: ${{ vars.QUERYLAKE_LIVE_QUERY_CASES_PATH }}
+      QUERYLAKE_LIVE_DIAGNOSTICS_DIR: docs_tmp/RAG/ci/live_integration
       QUERYLAKE_LIVE_ALLOW_WRITE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.allow_write == 'true' && '1' || '0' }}
     steps:
       - name: Checkout
@@ -38,12 +46,18 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            sdk/python/pyproject.toml
 
       - name: Preflight live environment contract
         id: preflight
         run: python scripts/dev/live_integration_preflight.py
 
       - name: Run live integration tests
+        env:
+          QUERYLAKE_LIVE_RUN_NAMESPACE: ${{ steps.preflight.outputs.run_namespace }}
         run: |
           mkdir -p docs_tmp/RAG/ci/live_integration
           uv run --project sdk/python --extra dev pytest \

--- a/docs/sdk/CI_PROFILES.md
+++ b/docs/sdk/CI_PROFILES.md
@@ -34,11 +34,14 @@ This executes the same checks used in CI release guard:
 
 Workflow: `.github/workflows/sdk_checks.yml`
 
-- `sdk-light-matrix`: `make sdk-test` on Python `3.10`, `3.11`, `3.12`
 - `sdk-lint-type`: `make sdk-lint` + `make sdk-type` on Python `3.12`
-- `sdk-release-guard`: runs `scripts/dev/release_sdk.sh check` after both jobs pass
+- `sdk-light-matrix`: `make sdk-test` on Python `3.10`, `3.11`, `3.12` (tests-only matrix)
+- `sdk-release-guard`: guard script contract + single package build + `twine check` + wheel verification
 
-The matrix validates interpreter compatibility while avoiding duplicated lint/type cost.
+This layout removes duplicated full-quality runs while preserving all gates:
+- lint/type runs once
+- tests run per-Python
+- build/metadata/wheel checks run once
 
 ### 4) TestPyPI dry-run publish profile (`sdk_publish_dryrun.yml`)
 
@@ -64,10 +67,62 @@ Workflow: `.github/workflows/ci_runtime_profiler.yml`
 
 Workflow: `.github/workflows/sdk_live_integration.yml`
 
-- runs nightly + manual
+- runs manual only
 - enforces preflight environment contract before execution
 - defaults to read-only checks
 - optional manual write-path smoke with explicit enable switch
+- explicitly non-blocking for merge CI (release-confidence lane only)
+
+## Trigger and cost governance
+
+### Trigger policy
+
+- `sdk_checks.yml`:
+  - runs on PR/push for SDK-relevant paths only
+  - provides default quality gate signal
+  - applies uv cache keyed by SDK dependency file
+- `sdk_publish_dryrun.yml`:
+  - nightly + manual dispatch
+  - restricted to `main` by default (explicit non-main override available for trials)
+  - applies uv cache keyed by SDK dependency file
+- `sdk_live_integration.yml`:
+  - manual read-only by default
+  - manual write-path only when `allow_write=true`
+  - applies uv cache keyed by SDK dependency file
+- `retrieval_eval.yml`:
+  - PR/push triggers are path-filtered to retrieval/search/ingestion surfaces
+  - heavy profile remains dispatch-only
+- `ci_runtime_profiler.yml`:
+  - nightly + manual
+  - used for governance trend and regression detection
+  - supports configurable p95/compute regression thresholds and optional fail-on-regression
+
+### Weekly runtime/cost budget targets
+
+- `sdk_checks.yml`: target median <= 8 min, p95 <= 12 min
+- `sdk_publish_dryrun.yml`: target median <= 15 min, p95 <= 20 min
+- `sdk_live_integration.yml`: target median <= 12 min, p95 <= 18 min
+- aggregate SDK CI compute budget: <= 550 runner-minutes/week
+
+### Escalation policy
+
+Escalate to maintainer review when any of the following occurs for two consecutive days:
+
+1. p95 runtime regression > 15% versus baseline.
+2. workflow failure-rate > 10% for non-code reasons (infra/index/auth).
+3. weekly compute budget exceeded by > 20%.
+
+Required remediation output:
+
+- root-cause summary
+- reverted/adjusted workflow plan
+- expected rollback and verification window
+
+### Required-check stance
+
+- Merge-required quality gates: `sdk_checks.yml` (lint/type/test/release-guard) and policy checks tied to code quality.
+- Optional confidence lanes: `sdk_live_integration.yml` (manual live staging), retrieval heavy/nightly suites.
+- Rationale: avoid coupling PR throughput to external staging/network/secret availability while preserving a strong pre-release validation path.
 
 ## Publish policy
 

--- a/docs/sdk/LIVE_STAGING_INTEGRATION.md
+++ b/docs/sdk/LIVE_STAGING_INTEGRATION.md
@@ -10,8 +10,7 @@ Validate SDK + CLI behavior against a real QueryLake deployment while preventing
 
 - File: `.github/workflows/sdk_live_integration.yml`
 - Trigger:
-  - manual (`workflow_dispatch`)
-  - nightly schedule
+  - manual (`workflow_dispatch`) only
 - Test marker: `integration_live`
 - Test path: `sdk/python/tests/integration/`
 
@@ -24,6 +23,11 @@ Set these in GitHub repository vars/secrets:
 - `vars.QUERYLAKE_LIVE_TEST_COLLECTION_ID` (required for search and optional write smoke)
 - `vars.QUERYLAKE_LIVE_TEST_QUERY` (optional; defaults in test)
 - `vars.QUERYLAKE_LIVE_ALLOW_NON_STAGING` (optional; `1` to bypass host safety gate)
+- `vars.QUERYLAKE_LIVE_TIMEOUT_SECONDS` (optional; defaults to `20`)
+- `vars.QUERYLAKE_LIVE_RETRY_ATTEMPTS` (optional; defaults to `3`)
+- `vars.QUERYLAKE_LIVE_RETRY_DELAY_SECONDS` (optional; defaults to `1`)
+- `vars.QUERYLAKE_LIVE_STRICT_EXPECTATIONS` (optional; `1` enables deterministic term assertions)
+- `vars.QUERYLAKE_LIVE_QUERY_CASES_PATH` (optional; defaults to `sdk/python/tests/integration/live_query_cases.json`)
 
 Manual input:
 
@@ -39,6 +43,7 @@ Enforces:
 
 - base URL must exist
 - auth token/key must exist
+- placeholder values (e.g. `changeme`, `example`) are rejected
 - non-staging hosts blocked by default
 - write mode requires explicit test collection id
 
@@ -49,6 +54,10 @@ Enforces:
 3. Optional write-path smoke:
    - upload one document
    - delete the uploaded document in teardown
+4. Deterministic hybrid assertions (strict mode):
+   - run canonical query cases from fixture JSON
+   - enforce min row counts per case
+   - optionally enforce expected term hits in returned rows
 
 ## Fail-closed behavior
 
@@ -58,12 +67,80 @@ Enforces:
 
 ## Operational policy
 
-- Nightly run in read-only mode.
+- This workflow is intentionally **non-blocking** and **manual-only** for CI.
+- Use it as a pre-release confidence check, not a merge gate.
 - Write-path runs only on manual dispatch with explicit `allow_write=true`.
 - Any failure should include junit artifact and step summary for triage.
+- Integration tests emit `live_metrics.jsonl` with per-operation latency and retry outcomes.
+- Integration tests include best-effort request-id capture in `live_metrics.jsonl`.
+
+## Deterministic corpus and query fixture
+
+Fixture file:
+
+- `sdk/python/tests/integration/live_query_cases.json`
+
+Bootstrap an isolated integration collection (recommended once per environment):
+
+```bash
+uv run --project sdk/python \
+  python scripts/dev/live_integration_bootstrap.py \
+  --collection-title "SDK Live Integration Fixture"
+```
+
+Bootstrap output contract:
+
+- `docs_tmp/RAG/ci/live_integration/bootstrap_contract.json`
+- includes recommended values for:
+  - `QUERYLAKE_LIVE_TEST_COLLECTION_ID`
+  - `QUERYLAKE_LIVE_QUERY_CASES_PATH`
+  - `QUERYLAKE_LIVE_STRICT_EXPECTATIONS=1`
+
+It defines:
+
+- `documents`: canonical documents for deterministic live seeding
+- `cases`: canonical retrieval queries and minimum expected rows
+
+Seed the fixture corpus (manual, authenticated):
+
+```bash
+uv run --project sdk/python \
+  python scripts/dev/live_integration_seed_fixture.py \
+  --collection-id "$QUERYLAKE_LIVE_TEST_COLLECTION_ID" \
+  --create-embeddings \
+  --create-sparse-embeddings \
+  --await-embedding
+```
+
+Seed output manifest:
+
+- `docs_tmp/RAG/ci/live_integration/seed_fixture_results.json`
 
 ## Next extension points
 
 - Add collection lifecycle checks (create/modify/list + cleanup) once dedicated test tenant policy is finalized.
-- Add lane-specific retrieval parity assertions tied to known seeded corpus.
+- Add lane-specific retrieval parity assertions tied to known seeded corpus and capture lane-wise top-k drift trends.
 - Add run-level latency SLO thresholds and flaky-test tracking.
+
+## Observed failure modes and mitigations (2026-03-03)
+
+1. Missing credentials or base URL in workflow environment.
+   - symptom: preflight exits before tests
+   - mitigation: required vars/secrets contract, fail-closed before test execution
+
+2. Non-staging host accidentally targeted.
+   - symptom: preflight rejects host unless override is explicitly enabled
+   - mitigation: keep `QUERYLAKE_LIVE_ALLOW_NON_STAGING` unset by default
+
+3. Write-path run requested without test collection id.
+   - symptom: preflight hard-fails in write mode
+   - mitigation: require `QUERYLAKE_LIVE_TEST_COLLECTION_ID` whenever `allow_write=true`
+
+4. Transient staging/API instability during nightly/manual runs.
+   - symptom: intermittent integration failure
+   - mitigation: bounded retry/backoff in integration tests + retain `junit.xml` and `live_metrics.jsonl` artifacts for triage
+
+5. Repository-level live vars/secrets absent on branch validation runs.
+   - symptom: preflight fails with `QUERYLAKE_LIVE_BASE_URL is required` before tests start
+   - evidence: workflow run `22642371545` (`docs_tmp/RAG/ci/live_integration/run_22642371545_failed.log`)
+   - mitigation: define the required vars/secrets contract before manual live checks

--- a/scripts/dev/live_integration_bootstrap.py
+++ b/scripts/dev/live_integration_bootstrap.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Bootstrap isolated resources for SDK live integration checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:
+    from querylake_sdk import QueryLakeClient
+except ModuleNotFoundError:  # pragma: no cover - repo-local execution fallback
+    import sys
+
+    REPO_ROOT = Path(__file__).resolve().parents[2]
+    SDK_SRC = REPO_ROOT / "sdk/python/src"
+    if SDK_SRC.exists():
+        sys.path.insert(0, str(SDK_SRC))
+        from querylake_sdk import QueryLakeClient
+    else:
+        raise
+
+
+def _env(name: str) -> str:
+    return (os.getenv(name) or "").strip()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create or validate live integration collection resources.")
+    parser.add_argument("--base-url", default="", help="Override QueryLake base URL.")
+    parser.add_argument("--oauth2", default="", help="Override OAuth2 token.")
+    parser.add_argument("--api-key", default="", help="Override API key.")
+    parser.add_argument(
+        "--collection-title",
+        default="SDK Live Integration Fixture",
+        help="Title for the isolated integration collection.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="docs_tmp/RAG/ci/live_integration/bootstrap_contract.json",
+        help="Path for bootstrap contract output JSON.",
+    )
+    return parser.parse_args()
+
+
+def _build_client(args: argparse.Namespace) -> QueryLakeClient:
+    base_url = (args.base_url or _env("QUERYLAKE_LIVE_BASE_URL")).strip()
+    oauth2 = (args.oauth2 or _env("QUERYLAKE_LIVE_OAUTH2")).strip()
+    api_key = (args.api_key or _env("QUERYLAKE_LIVE_API_KEY")).strip()
+    if not base_url:
+        raise SystemExit("Missing base URL (use --base-url or QUERYLAKE_LIVE_BASE_URL).")
+    if not oauth2 and not api_key:
+        raise SystemExit("Missing auth credentials (oauth2/api-key).")
+    kwargs: Dict[str, Any] = {"base_url": base_url}
+    if oauth2:
+        kwargs["oauth2"] = oauth2
+    if api_key:
+        kwargs["api_key"] = api_key
+    return QueryLakeClient(**kwargs)
+
+
+def _extract_collection_rows(payload: Any) -> List[Dict[str, Any]]:
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    if isinstance(payload, dict):
+        for key in ("collections", "rows", "result", "items"):
+            candidate = payload.get(key)
+            if isinstance(candidate, list):
+                return [row for row in candidate if isinstance(row, dict)]
+    return []
+
+
+def _collection_identity(row: Dict[str, Any]) -> str:
+    return str(
+        row.get("hash_id")
+        or row.get("collection_hash_id")
+        or row.get("id")
+        or ""
+    ).strip()
+
+
+def main() -> int:
+    args = parse_args()
+    client = _build_client(args)
+    try:
+        title = str(args.collection_title or "").strip()
+        if not title:
+            raise SystemExit("collection title must be non-empty")
+
+        listed = client.list_collections()
+        rows = _extract_collection_rows(listed)
+        existing = next((row for row in rows if str(row.get("name") or row.get("title") or "").strip() == title), None)
+
+        created = False
+        if existing is None:
+            created_payload = client.create_collection(
+                name=title,
+                description="Dedicated deterministic corpus for SDK live integration tests.",
+                public=False,
+            )
+            created = True
+            candidate_id = _collection_identity(created_payload)
+            if candidate_id:
+                collection_id = candidate_id
+            else:
+                # Fallback to fresh list lookup by title.
+                listed = client.list_collections()
+                rows = _extract_collection_rows(listed)
+                matched = next(
+                    (row for row in rows if str(row.get("name") or row.get("title") or "").strip() == title),
+                    None,
+                )
+                if matched is None:
+                    raise SystemExit("Collection created but could not be re-discovered by title.")
+                existing = matched
+                collection_id = _collection_identity(existing)
+        else:
+            collection_id = _collection_identity(existing)
+
+        if not collection_id:
+            raise SystemExit("Unable to resolve collection id for integration collection.")
+
+        contract = {
+            "base_url": client.base_url,
+            "collection_title": title,
+            "collection_id": collection_id,
+            "created": created,
+            "env_contract": {
+                "QUERYLAKE_LIVE_BASE_URL": client.base_url,
+                "QUERYLAKE_LIVE_TEST_COLLECTION_ID": collection_id,
+                "QUERYLAKE_LIVE_QUERY_CASES_PATH": "sdk/python/tests/integration/live_query_cases.json",
+                "QUERYLAKE_LIVE_STRICT_EXPECTATIONS": "1",
+            },
+        }
+
+        output_path = Path(args.output_json).expanduser().resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(json.dumps(contract, indent=2, sort_keys=True))
+    finally:
+        client.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/live_integration_preflight.py
+++ b/scripts/dev/live_integration_preflight.py
@@ -13,6 +13,20 @@ from urllib.parse import urlparse
 
 
 SAFE_HOST_HINTS = ("staging", "dev", "localhost", "127.0.0.1")
+PLACEHOLDER_SUBSTRINGS = (
+    "changeme",
+    "replace",
+    "placeholder",
+    "example",
+    "dummy",
+    "todo",
+    "<token>",
+    "<key>",
+    "<secret>",
+    "your_",
+    "xxx",
+    "test-token",
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -24,6 +38,17 @@ def parse_args() -> argparse.Namespace:
 def fail(message: str) -> int:
     print(f"[live-preflight] FAILED: {message}", file=sys.stderr)
     return 1
+
+
+def _looks_placeholder(value: str) -> bool:
+    normalized = (value or "").strip().lower()
+    if not normalized:
+        return False
+    if normalized in {"none", "null", "unset"}:
+        return True
+    if normalized.startswith("${") and normalized.endswith("}"):
+        return True
+    return any(token in normalized for token in PLACEHOLDER_SUBSTRINGS)
 
 
 def main() -> int:
@@ -39,8 +64,19 @@ def main() -> int:
         return fail("QUERYLAKE_LIVE_BASE_URL is required.")
     if not oauth2 and not api_key:
         return fail("Either QUERYLAKE_LIVE_OAUTH2 or QUERYLAKE_LIVE_API_KEY is required.")
+    if _looks_placeholder(base_url):
+        return fail("QUERYLAKE_LIVE_BASE_URL looks like a placeholder value.")
+    if oauth2 and _looks_placeholder(oauth2):
+        return fail("QUERYLAKE_LIVE_OAUTH2 looks like a placeholder value.")
+    if api_key and _looks_placeholder(api_key):
+        return fail("QUERYLAKE_LIVE_API_KEY looks like a placeholder value.")
 
-    hostname = (urlparse(base_url).hostname or "").lower()
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"}:
+        return fail("QUERYLAKE_LIVE_BASE_URL must include http:// or https:// scheme.")
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        return fail("QUERYLAKE_LIVE_BASE_URL must include a valid hostname.")
     if not allow_non_staging and hostname and not any(hint in hostname for hint in SAFE_HOST_HINTS):
         return fail(
             "Refusing to run against non-staging host. "
@@ -58,6 +94,8 @@ def main() -> int:
         "allow_non_staging": allow_non_staging,
         "allow_write": allow_write,
         "write_collection_id_set": bool(write_collection),
+        "strict_expectations": (os.getenv("QUERYLAKE_LIVE_STRICT_EXPECTATIONS") or "").strip() == "1",
+        "query_cases_path": (os.getenv("QUERYLAKE_LIVE_QUERY_CASES_PATH") or "").strip(),
         "run_namespace": run_namespace,
     }
     print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/dev/live_integration_seed_fixture.py
+++ b/scripts/dev/live_integration_seed_fixture.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Seed deterministic documents for SDK live integration retrieval checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:
+    from querylake_sdk import QueryLakeClient
+except ModuleNotFoundError:  # pragma: no cover - repo-local execution fallback
+    import sys
+
+    REPO_ROOT = Path(__file__).resolve().parents[2]
+    SDK_SRC = REPO_ROOT / "sdk/python/src"
+    if SDK_SRC.exists():
+        sys.path.insert(0, str(SDK_SRC))
+        from querylake_sdk import QueryLakeClient
+    else:
+        raise
+
+
+def _env(name: str) -> str:
+    return (os.getenv(name) or "").strip()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Seed deterministic live integration fixture documents.")
+    parser.add_argument(
+        "--fixture-path",
+        default="sdk/python/tests/integration/live_query_cases.json",
+        help="Path to fixture JSON containing a 'documents' list.",
+    )
+    parser.add_argument(
+        "--collection-id",
+        default="",
+        help="Collection hash id. Defaults to QUERYLAKE_LIVE_TEST_COLLECTION_ID.",
+    )
+    parser.add_argument(
+        "--create-embeddings",
+        action="store_true",
+        help="If set, request dense embedding generation during upload.",
+    )
+    parser.add_argument(
+        "--create-sparse-embeddings",
+        action="store_true",
+        help="If set, request sparse embedding generation during upload.",
+    )
+    parser.add_argument(
+        "--await-embedding",
+        action="store_true",
+        help="If set, wait for embedding pipeline completion at upload time.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="docs_tmp/RAG/ci/live_integration/seed_fixture_results.json",
+        help="Where to write seed result manifest JSON.",
+    )
+    return parser.parse_args()
+
+
+def _build_client() -> QueryLakeClient:
+    base_url = _env("QUERYLAKE_LIVE_BASE_URL")
+    oauth2 = _env("QUERYLAKE_LIVE_OAUTH2")
+    api_key = _env("QUERYLAKE_LIVE_API_KEY")
+    if not base_url:
+        raise SystemExit("Missing QUERYLAKE_LIVE_BASE_URL.")
+    if not oauth2 and not api_key:
+        raise SystemExit("Missing QUERYLAKE_LIVE_OAUTH2 / QUERYLAKE_LIVE_API_KEY.")
+
+    kwargs: Dict[str, Any] = {"base_url": base_url}
+    if oauth2:
+        kwargs["oauth2"] = oauth2
+    if api_key:
+        kwargs["api_key"] = api_key
+    return QueryLakeClient(**kwargs)
+
+
+def _load_documents(path: Path) -> List[Dict[str, str]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - utility script
+        raise SystemExit(f"Failed to parse fixture JSON: {path} ({exc})")
+    docs = payload.get("documents")
+    if not isinstance(docs, list) or not docs:
+        raise SystemExit(f"Fixture must include non-empty 'documents' list: {path}")
+    normalized: List[Dict[str, str]] = []
+    for raw in docs:
+        if not isinstance(raw, dict):
+            continue
+        doc_id = str(raw.get("doc_id") or "").strip()
+        filename = str(raw.get("filename") or f"{doc_id or 'seed'}.txt").strip()
+        content = str(raw.get("content") or "").strip()
+        if not content:
+            continue
+        normalized.append(
+            {
+                "doc_id": doc_id or filename,
+                "filename": filename,
+                "content": content,
+            }
+        )
+    if not normalized:
+        raise SystemExit("No valid fixture documents found.")
+    return normalized
+
+
+def main() -> int:
+    args = parse_args()
+    fixture_path = Path(args.fixture_path).expanduser().resolve()
+    if not fixture_path.exists():
+        raise SystemExit(f"Fixture path does not exist: {fixture_path}")
+
+    collection_id = (args.collection_id or _env("QUERYLAKE_LIVE_TEST_COLLECTION_ID")).strip()
+    if not collection_id:
+        raise SystemExit("Missing collection id (pass --collection-id or set QUERYLAKE_LIVE_TEST_COLLECTION_ID).")
+
+    docs = _load_documents(fixture_path)
+    output_path = Path(args.output_json).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fixture_tag = fixture_path.stem
+    results: List[Dict[str, Any]] = []
+    client = _build_client()
+    try:
+        with tempfile.TemporaryDirectory(prefix="qlsdk_live_seed_") as tmp:
+            tmp_path = Path(tmp)
+            for doc in docs:
+                file_path = tmp_path / doc["filename"]
+                file_path.write_text(doc["content"], encoding="utf-8")
+                idempotency_key = f"qlsdk-live-seed:{fixture_tag}:{doc['doc_id']}"
+                response = client.upload_document(
+                    file_path=file_path,
+                    collection_hash_id=collection_id,
+                    scan_text=True,
+                    create_embeddings=bool(args.create_embeddings),
+                    create_sparse_embeddings=bool(args.create_sparse_embeddings),
+                    await_embedding=bool(args.await_embedding),
+                    idempotency_key=idempotency_key,
+                    document_metadata={
+                        "source": "sdk_live_seed_fixture",
+                        "fixture": fixture_tag,
+                        "seed_doc_id": doc["doc_id"],
+                    },
+                )
+                results.append(
+                    {
+                        "doc_id": doc["doc_id"],
+                        "filename": doc["filename"],
+                        "idempotency_key": idempotency_key,
+                        "hash_id": response.get("hash_id"),
+                        "created": bool(response.get("created", True)),
+                    }
+                )
+    finally:
+        client.close()
+
+    summary = {
+        "fixture_path": str(fixture_path),
+        "collection_id": collection_id,
+        "documents_seeded": len(results),
+        "results": results,
+    }
+    output_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/tests/integration/live_query_cases.json
+++ b/sdk/python/tests/integration/live_query_cases.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "description": "Canonical live-integration retrieval cases for seeded test corpus.",
+  "documents": [
+    {
+      "doc_id": "seed_boiler_pressure",
+      "filename": "boiler_pressure_limits.txt",
+      "content": "Boiler pressure limits guidance: maintain safe pressure envelopes and inspect relief valves before operation."
+    },
+    {
+      "doc_id": "seed_mineral_oil",
+      "filename": "mineral_oil_procedures.txt",
+      "content": "Mineral oil procedures include sampling protocols, contamination checks, and standardized maintenance records."
+    },
+    {
+      "doc_id": "seed_flue_gas",
+      "filename": "flue_gas_analysis.txt",
+      "content": "Flue gas analysis guides describe oxygen and CO2 measurement workflows for combustion tuning."
+    }
+  ],
+  "cases": [
+    {
+      "name": "boiler_pressure_limits",
+      "query": "boiler pressure limits",
+      "min_rows": 1,
+      "expected_terms_any": ["boiler", "pressure"]
+    },
+    {
+      "name": "mineral_oil_procedures",
+      "query": "mineral oil procedures",
+      "min_rows": 1,
+      "expected_terms_any": ["mineral", "oil"]
+    },
+    {
+      "name": "flue_gas_analysis_guides",
+      "query": "flue gas analysis guides",
+      "min_rows": 1,
+      "expected_terms_any": ["flue", "gas"]
+    }
+  ]
+}

--- a/sdk/python/tests/integration/test_live_smoke.py
+++ b/sdk/python/tests/integration/test_live_smoke.py
@@ -2,18 +2,32 @@ from __future__ import annotations
 
 import os
 import tempfile
+import time
+import json
 from pathlib import Path
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
 from querylake_sdk import QueryLakeClient
+from querylake_sdk.errors import QueryLakeHTTPStatusError, QueryLakeTransportError
 
 
 pytestmark = pytest.mark.integration_live
+_DEFAULT_CASES_PATH = Path(__file__).with_name("live_query_cases.json")
 
 
 def _env(name: str) -> str:
     return (os.getenv(name) or "").strip()
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = _env(name).lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return bool(default)
 
 
 def _require_enabled() -> None:
@@ -29,7 +43,8 @@ def _build_client() -> QueryLakeClient:
         pytest.skip("Missing QUERYLAKE_LIVE_BASE_URL.")
     if not oauth2 and not api_key:
         pytest.skip("Missing QUERYLAKE_LIVE_OAUTH2 / QUERYLAKE_LIVE_API_KEY.")
-    kwargs = {"base_url": base_url}
+    timeout_seconds = float(_env("QUERYLAKE_LIVE_TIMEOUT_SECONDS") or "20")
+    kwargs = {"base_url": base_url, "timeout_seconds": timeout_seconds}
     if oauth2:
         kwargs["oauth2"] = oauth2
     if api_key:
@@ -37,47 +52,245 @@ def _build_client() -> QueryLakeClient:
     return QueryLakeClient(**kwargs)
 
 
+def _diagnostics_dir() -> Path:
+    value = _env("QUERYLAKE_LIVE_DIAGNOSTICS_DIR") or "docs_tmp/RAG/ci/live_integration"
+    path = Path(value).expanduser().resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _extract_request_id_from_headers(headers: Dict[str, str]) -> str:
+    for key in ("x-request-id", "x-correlation-id", "request-id"):
+        value = (headers.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _extract_request_id_from_payload(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    # QueryLake routes may include request correlation in metadata envelopes.
+    for key in ("request_id", "requestId", "trace_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    md = payload.get("md")
+    if isinstance(md, dict):
+        for key in ("request_id", "trace_id"):
+            value = md.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _record_diag(
+    test_name: str,
+    op: str,
+    started_at: float,
+    ok: bool,
+    note: str = "",
+    *,
+    request_id: str = "",
+    status_code: int | None = None,
+) -> None:
+    payload = {
+        "test": test_name,
+        "op": op,
+        "ok": bool(ok),
+        "latency_ms": round((time.perf_counter() - started_at) * 1000.0, 2),
+        "note": note,
+        "request_id": request_id,
+        "status_code": status_code,
+        "run_namespace": _env("QUERYLAKE_LIVE_RUN_NAMESPACE") or "",
+    }
+    with (_diagnostics_dir() / "live_metrics.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _call_with_retry(test_name: str, op: str, fn):
+    attempts = int(_env("QUERYLAKE_LIVE_RETRY_ATTEMPTS") or "3")
+    delay_seconds = float(_env("QUERYLAKE_LIVE_RETRY_DELAY_SECONDS") or "1")
+    for attempt in range(1, max(1, attempts) + 1):
+        started = time.perf_counter()
+        try:
+            result = fn()
+            _record_diag(test_name, f"{op}#{attempt}", started, True)
+            return result
+        except QueryLakeTransportError as exc:
+            _record_diag(test_name, f"{op}#{attempt}", started, False, f"transport:{exc}")
+            if attempt >= attempts:
+                raise
+            time.sleep(delay_seconds)
+        except QueryLakeHTTPStatusError as exc:
+            _record_diag(test_name, f"{op}#{attempt}", started, False, f"http:{exc.status_code}")
+            if attempt >= attempts or exc.status_code < 500:
+                raise
+            time.sleep(delay_seconds)
+
+
+def _call_json_route_with_retry(
+    test_name: str,
+    op: str,
+    client: QueryLakeClient,
+    method: str,
+    path: str,
+    *,
+    json_payload: Dict[str, Any] | None = None,
+) -> Tuple[Any, str]:
+    attempts = int(_env("QUERYLAKE_LIVE_RETRY_ATTEMPTS") or "3")
+    delay_seconds = float(_env("QUERYLAKE_LIVE_RETRY_DELAY_SECONDS") or "1")
+    for attempt in range(1, max(1, attempts) + 1):
+        started = time.perf_counter()
+        try:
+            response = client._request(method, path, json=json_payload)  # noqa: SLF001
+            payload = response.json()
+            request_id = _extract_request_id_from_headers(dict(response.headers))
+            if not request_id:
+                request_id = _extract_request_id_from_payload(payload)
+            _record_diag(
+                test_name,
+                f"{op}#{attempt}",
+                started,
+                True,
+                request_id=request_id,
+                status_code=response.status_code,
+            )
+            return payload, request_id
+        except QueryLakeTransportError as exc:
+            _record_diag(test_name, f"{op}#{attempt}", started, False, f"transport:{exc}")
+            if attempt >= attempts:
+                raise
+            time.sleep(delay_seconds)
+        except QueryLakeHTTPStatusError as exc:
+            _record_diag(test_name, f"{op}#{attempt}", started, False, f"http:{exc.status_code}")
+            if attempt >= attempts or exc.status_code < 500:
+                raise
+            time.sleep(delay_seconds)
+    raise RuntimeError("unreachable retry loop")
+
+
+def _row_blob_text(row: Dict[str, Any]) -> str:
+    pieces: List[str] = []
+    for key in (
+        "text",
+        "content",
+        "document_title",
+        "document_name",
+        "chunk",
+        "chunk_text",
+        "title",
+    ):
+        value = row.get(key)
+        if isinstance(value, str) and value.strip():
+            pieces.append(value.strip().lower())
+    return "\n".join(pieces)
+
+
+def _load_query_cases() -> List[Dict[str, Any]]:
+    cases_path = _env("QUERYLAKE_LIVE_QUERY_CASES_PATH")
+    path = Path(cases_path).expanduser() if cases_path else _DEFAULT_CASES_PATH
+    if not path.exists():
+        query = _env("QUERYLAKE_LIVE_TEST_QUERY") or "boiler pressure limits"
+        return [{"name": "fallback", "query": query, "min_rows": 1, "expected_terms_any": []}]
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        pytest.skip(f"Unable to parse query cases file: {path} ({exc})")
+    if not isinstance(data, dict) or not isinstance(data.get("cases"), list):
+        pytest.skip(f"Query cases file must contain object with 'cases' list: {path}")
+    cases: List[Dict[str, Any]] = []
+    for idx, raw in enumerate(data.get("cases", []), start=1):
+        if not isinstance(raw, dict):
+            continue
+        query = str(raw.get("query") or "").strip()
+        if not query:
+            continue
+        terms = raw.get("expected_terms_any") or []
+        if not isinstance(terms, list):
+            terms = []
+        cases.append(
+            {
+                "name": str(raw.get("name") or f"case_{idx}"),
+                "query": query,
+                "min_rows": int(raw.get("min_rows") or 1),
+                "expected_terms_any": [str(term).strip().lower() for term in terms if str(term).strip()],
+            }
+        )
+    return cases
+
+
 def test_live_health_ready_and_models() -> None:
+    test_name = "test_live_health_ready_and_models"
     _require_enabled()
     client = _build_client()
     try:
-        health = client.healthz()
-        ready = client.readyz()
-        models = client.list_models()
+        health, health_req_id = _call_json_route_with_retry(test_name, "healthz", client, "GET", "/healthz")
+        ready, ready_req_id = _call_json_route_with_retry(test_name, "readyz", client, "GET", "/readyz")
+        models, models_req_id = _call_json_route_with_retry(test_name, "list_models", client, "GET", "/v1/models")
         assert isinstance(health, dict)
         assert isinstance(ready, dict)
         assert isinstance(models, dict)
+        # Keep request-id visibility best-effort; some deployments may not emit one per route.
+        assert isinstance(health_req_id, str)
+        assert isinstance(ready_req_id, str)
+        assert isinstance(models_req_id, str)
     finally:
         client.close()
 
 
 def test_live_hybrid_search_smoke() -> None:
+    test_name = "test_live_hybrid_search_smoke"
     _require_enabled()
     collection_id = _env("QUERYLAKE_LIVE_TEST_COLLECTION_ID")
     if not collection_id:
         pytest.skip("Missing QUERYLAKE_LIVE_TEST_COLLECTION_ID for live search smoke.")
-    query = _env("QUERYLAKE_LIVE_TEST_QUERY") or "boiler pressure limits"
+    query_cases = _load_query_cases()
+    strict_expectations = _env_bool("QUERYLAKE_LIVE_STRICT_EXPECTATIONS", default=False)
 
     client = _build_client()
     try:
-        rows = client.search_hybrid_with_metrics(
-            query=query,
-            collection_ids=[collection_id],
-            limit=3,
-            limit_bm25=6,
-            limit_similarity=6,
-            limit_sparse=0,
-            bm25_weight=0.6,
-            similarity_weight=0.4,
-            sparse_weight=0.0,
-        )
-        assert isinstance(rows, dict)
-        assert "rows" in rows
+        for case in query_cases:
+            query = str(case.get("query") or "").strip()
+            if not query:
+                continue
+            payload, request_id = _call_json_route_with_retry(
+                test_name,
+                f"search_hybrid:{case.get('name')}",
+                client,
+                "POST",
+                "/api/search_hybrid",
+                json_payload={
+                    "query": query,
+                    "collection_ids": [collection_id],
+                    "limit": 3,
+                    "limit_bm25": 6,
+                    "limit_similarity": 6,
+                    "limit_sparse": 0,
+                    "bm25_weight": 0.6,
+                    "similarity_weight": 0.4,
+                    "sparse_weight": 0.0,
+                },
+            )
+            assert isinstance(payload, dict)
+            rows = payload.get("rows")
+            assert isinstance(rows, list)
+            assert len(rows) >= int(case.get("min_rows") or 1)
+
+            expected_terms = case.get("expected_terms_any") or []
+            if strict_expectations and expected_terms:
+                blob = "\n".join(_row_blob_text(row) for row in rows if isinstance(row, dict))
+                assert any(term in blob for term in expected_terms), (
+                    f"Missing expected terms for case '{case.get('name')}': {expected_terms}"
+                )
+            assert isinstance(request_id, str)
     finally:
         client.close()
 
 
 def test_live_upload_delete_smoke() -> None:
+    test_name = "test_live_upload_delete_smoke"
     _require_enabled()
     if _env("QUERYLAKE_LIVE_ALLOW_WRITE") != "1":
         pytest.skip("Write-path live test disabled (set QUERYLAKE_LIVE_ALLOW_WRITE=1).")
@@ -91,19 +304,26 @@ def test_live_upload_delete_smoke() -> None:
         path = Path(tmp) / "live_smoke.txt"
         path.write_text("querylake live integration smoke payload", encoding="utf-8")
         try:
-            payload = client.upload_document(
-                file_path=path,
-                collection_hash_id=collection_id,
-                scan_text=True,
-                create_embeddings=False,
-                create_sparse_embeddings=False,
-                await_embedding=False,
-                document_metadata={"source": "sdk_live_smoke"},
+            payload = _call_with_retry(
+                test_name,
+                "upload_document",
+                lambda: client.upload_document(
+                    file_path=path,
+                    collection_hash_id=collection_id,
+                    scan_text=True,
+                    create_embeddings=False,
+                    create_sparse_embeddings=False,
+                    await_embedding=False,
+                    document_metadata={
+                        "source": "sdk_live_smoke",
+                        "run_namespace": _env("QUERYLAKE_LIVE_RUN_NAMESPACE") or "",
+                    },
+                ),
             )
             assert isinstance(payload, dict)
             doc_id = str(payload.get("hash_id") or "")
             assert doc_id
         finally:
             if doc_id:
-                client.delete_document(document_hash_id=doc_id)
+                _call_with_retry(test_name, "delete_document", lambda: client.delete_document(document_hash_id=doc_id))
     client.close()


### PR DESCRIPTION
## Summary
- finalize sdk live integration workflow as a manual-only confidence lane
- harden preflight checks for placeholder/scheme/hostname validation
- add fixture bootstrap/seed scripts and canonical live query case pack
- extend live integration tests with strict expectation/case-file controls

## Validation
- python -m py_compile scripts/dev/live_integration_preflight.py scripts/dev/live_integration_bootstrap.py scripts/dev/live_integration_seed_fixture.py
