### PR TITLE
chore(make): idempotent db/redis up/down targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,28 @@ up-db:
 	fi
 
 down-db:
-	docker compose -f docker-compose-only-db.yml down
+	@if docker ps -a --format '{{.Names}}' | grep -qx 'querylake_db'; then \
+		docker compose -f docker-compose-only-db.yml down; \
+	else \
+		echo "[down-db] querylake_db not present; nothing to do."; \
+	fi
 
 up-redis:
-	docker compose -f docker-compose-redis.yml up -d
+	@if docker ps --format '{{.Names}}' | grep -qx 'querylake_redis'; then \
+		echo "[up-redis] querylake_redis already running; reusing existing container."; \
+	elif docker ps -a --format '{{.Names}}' | grep -qx 'querylake_redis'; then \
+		echo "[up-redis] querylake_redis exists but is stopped; starting container."; \
+		docker start querylake_redis >/dev/null; \
+	else \
+		docker compose -f docker-compose-redis.yml up -d; \
+	fi
 
 down-redis:
-	docker compose -f docker-compose-redis.yml down
+	@if docker ps -a --format '{{.Names}}' | grep -qx 'querylake_redis'; then \
+		docker compose -f docker-compose-redis.yml down; \
+	else \
+		echo "[down-redis] querylake_redis not present; nothing to do."; \
+	fi
 
 run:
 	uv run start_querylake.py


### PR DESCRIPTION
## Summary
- make down-db no-op cleanly when querylake_db is absent
- make up-redis reuse running container or start stopped container before falling back to compose up
- make down-redis no-op cleanly when querylake_redis is absent

## Notes
- avoids noisy/conflicting local setup behavior across multiple working trees
- preserves existing container names and compose wiring

## Validation
- make up-redis returns reuse message when container is already running
- make -n down-db up-redis down-redis confirms expected control-flow paths