### PR TITLE
ci: add guard against legacy QueryLakeBackend references

### DIFF
--- a/.github/workflows/legacy_path_guard.yml
+++ b/.github/workflows/legacy_path_guard.yml
@@ -1,0 +1,18 @@
+name: Legacy Path Guard
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  legacy-path-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enforce canonical QueryLake naming
+        run: make ci-legacy-path-guard
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: bootstrap up-db down-db up-redis down-redis run run-api-only health test ci-docs ci-unification ci-retrieval-smoke ci-runtime-profile ci-runtime-delta sdk-install-dev sdk-precommit-install sdk-precommit-run sdk-lint sdk-type sdk-test sdk-build sdk-ci sdk-smoke sdk-release-check sdk-release-testpypi sdk-release-pypi sdk-publish-guard sdk-dryrun-version
+.PHONY: bootstrap up-db down-db up-redis down-redis run run-api-only health test ci-docs ci-unification ci-retrieval-smoke ci-runtime-profile ci-runtime-delta ci-legacy-path-guard sdk-install-dev sdk-precommit-install sdk-precommit-run sdk-lint sdk-type sdk-test sdk-build sdk-ci sdk-smoke sdk-release-check sdk-release-testpypi sdk-release-pypi sdk-publish-guard sdk-dryrun-version
 
 bootstrap:
 	./scripts/dev/bootstrap.sh
@@ -96,6 +96,9 @@ ci-runtime-delta:
 		--before-json "$(BEFORE)" \
 		--after-json "$(AFTER)" \
 		--out-md "$$OUT"
+
+ci-legacy-path-guard:
+	bash scripts/ci_guard_legacy_querylakebackend_refs.sh
 
 sdk-install-dev:
 	uv run --project sdk/python pip install -e sdk/python

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -4,7 +4,7 @@ This repository is **deprecated**.
 
 Frontend development has moved to the main QueryLake repository:
 
-- https://github.com/kmccleary3301/QueryLakeBackend
+- https://github.com/kmccleary3301/QueryLake
 
 ## Status
 

--- a/scripts/ci_guard_legacy_querylakebackend_refs.sh
+++ b/scripts/ci_guard_legacy_querylakebackend_refs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Historical migration documentation is allowed to mention the previous repo name.
+ALLOW_EXCLUDES=(
+  ":(exclude)docs/unification/repo_migration.md"
+  ":(exclude)scripts/ci_guard_legacy_querylakebackend_refs.sh"
+)
+
+PATTERN='QueryLakeBackend|/shared_folders/querylake_server/QueryLakeBackend'
+
+if MATCHES="$(git grep -n -I -E "$PATTERN" -- . "${ALLOW_EXCLUDES[@]}" || true)"; then
+  :
+fi
+
+if [[ -n "${MATCHES// }" ]]; then
+  echo "ERROR: Legacy QueryLakeBackend reference(s) detected."
+  echo "Please migrate to the canonical QueryLake naming."
+  echo
+  echo "$MATCHES"
+  exit 1
+fi
+
+echo "Legacy path/name guard passed."
+


### PR DESCRIPTION
## Summary
- add scripts/ci_guard_legacy_querylakebackend_refs.sh to fail CI on new legacy QueryLakeBackend references
- add make ci-legacy-path-guard target
- add lightweight workflow .github/workflows/legacy_path_guard.yml
- update apps/studio/README.md canonical repo URL to QueryLake

## Allow-list
- historical migration note remains allowed in docs/unification/repo_migration.md

## Validation
- make ci-legacy-path-guard