### PR TITLE
fix(retrieval): wildcard file-chunk search + orchestration direct-call hardening

### DIFF
--- a/QueryLake/api/search.py
+++ b/QueryLake/api/search.py
@@ -2690,11 +2690,10 @@ def search_file_chunks(
             )
 
             def _direct_file_chunks(**kwargs):
-                return search_file_chunks(
-                    **kwargs,
-                    _direct_stage_call=True,
-                    _skip_observability=True,
-                )
+                direct_kwargs = dict(kwargs)
+                direct_kwargs["_direct_stage_call"] = True
+                direct_kwargs["_skip_observability"] = True
+                return search_file_chunks(**direct_kwargs)
 
             run_result = _run_async_sync(
                 PipelineOrchestrator().run(
@@ -2779,8 +2778,11 @@ def search_file_chunks(
 
     formatted_query, _ = parse_search(query, FILE_FIELDS, catch_all_fields=["text"])
 
-    score_field = "paradedb.score(fc.id) AS score, " if formatted_query != "()" else ""
-    assert not (sort_by == "score" and formatted_query == "()"), "Cannot sort by score if no query is specified"
+    query_is_empty = (formatted_query == "()")
+    if query_is_empty and sort_by == "score":
+        # For wildcard/empty queries there is no BM25 score; use recency ordering.
+        sort_by = "created_at"
+    score_field = "paradedb.score(fc.id) AS score, " if not query_is_empty else ""
     assert sort_by in FILE_FIELDS or sort_by == "score", f"sort_by must be one of {FILE_FIELDS} or 'score'"
     assert sort_dir in ["DESC", "ASC"], "sort_dir must be 'DESC' or 'ASC'"
 
@@ -2789,29 +2791,28 @@ def search_file_chunks(
     else:
         order_by_field = f"ORDER BY {sort_by} {sort_dir}" + (", fc.id ASC" if sort_by != "id" else "")
 
-    parse_field = formatted_query if formatted_query != "()" else "()"
+    where_clause = "f.created_by = :username"
+    if not query_is_empty:
+        where_clause = f"{where_clause} AND fc.id @@@ paradedb.parse('{formatted_query}')"
 
-    STMT = text(f"""
+    STMT = text(
+        f"""
     SELECT fc.id, {score_field}fc.id, fc.text, fc.md, fc.created_at, fc.file_version_id
     FROM {FileChunkTable.__tablename__} fc
     JOIN {FileVersionTable.__tablename__} fv ON fc.file_version_id = fv.id
     JOIN {FileTable.__tablename__} f ON fv.file_id = f.id
-    WHERE f.created_by = :username
-      AND fc.id @@@ paradedb.parse('{parse_field}')
+    WHERE {where_clause}
     {order_by_field}
     LIMIT :limit
     OFFSET :offset;
-    """).bindparams(
-        username=username,
-        limit=limit,
-        offset=offset,
-    )
+    """
+    ).bindparams(username=username, limit=limit, offset=offset)
 
     if return_statement:
         return str(STMT.compile(compile_kwargs={"literal_binds": True}))
 
     try:
-        subset_start = 1 if formatted_query == "()" else 2
+        subset_start = 1 if query_is_empty else 2
         rows = list(database.exec(STMT))
         results = []
         for row in rows:
@@ -2824,7 +2825,7 @@ def search_file_chunks(
                     "md": row[idx + 2],
                     "created_at": float(row[idx + 3]),
                     "file_version_id": row[idx + 4],
-                    **({"bm25_score": float(row[1])} if formatted_query != "()" else {}),
+                    **({"bm25_score": float(row[1])} if not query_is_empty else {}),
                 }
             )
         if not _skip_observability:

--- a/QueryLake/files/service.py
+++ b/QueryLake/files/service.py
@@ -514,7 +514,7 @@ class FilesRuntimeService:
         f = T.file(
             logical_name=logical_name,
             created_at=time.time(),
-            created_by=getattr(auth, "username", None),
+            created_by=username,
             collection_id=collection_id,
         )
         self.db.add(f)

--- a/tests/test_retrieval_orchestrated_compat.py
+++ b/tests/test_retrieval_orchestrated_compat.py
@@ -362,3 +362,103 @@ def test_search_file_chunks_orchestrated_path_emits_stage_trace(monkeypatch):
     assert result["results"][0]["id"] == "fc_1"
     assert logged["kwargs"]["pipeline_id"] == "orchestrated.search_file_chunks"
     assert "stage_trace" in logged["kwargs"]["md"]
+
+
+def test_search_file_chunks_orchestrated_direct_wrapper_avoids_duplicate_kwargs(monkeypatch):
+    db = _DummyDB()
+    monkeypatch.setattr(search_api, "get_user", lambda database, auth: (SimpleNamespace(), SimpleNamespace(username="tester")))
+
+    pipeline = RetrievalPipelineSpec(
+        pipeline_id="orchestrated.search_file_chunks",
+        version="v1",
+        stages=[RetrievalPipelineStage(stage_id="file_bm25", primitive_id="FileChunkBM25RetrieverSQL")],
+    )
+    monkeypatch.setattr(
+        search_api,
+        "_resolve_route_pipeline",
+        lambda *args, **kwargs: (pipeline, {"source": "test"}),
+    )
+
+    original_search_file_chunks = search_api.search_file_chunks
+
+    def _stub_direct_stage_call(**kwargs):
+        # This stub must be called by the nested wrapper without duplicate kwargs errors.
+        assert kwargs.get("_direct_stage_call") is True
+        assert kwargs.get("_skip_observability") is True
+        return {
+            "results": [
+                {
+                    "id": "fc_wrapped_1",
+                    "text": "wrapped text",
+                    "md": {"source": "stub"},
+                    "created_at": 42.0,
+                    "file_version_id": "fv_wrapped_1",
+                    "bm25_score": 0.91,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(search_api, "search_file_chunks", _stub_direct_stage_call)
+
+    class _TriggerRetriever:
+        def __init__(self, fn):
+            self._fn = fn
+
+        async def retrieve(self, request):
+            payload = self._fn(
+                database=db,
+                auth={"username": "tester", "password_prehash": "x"},
+                query=request.query_text,
+                limit=1,
+                offset=0,
+                sort_by="created_at",
+                sort_dir="DESC",
+                _direct_stage_call=True,
+                _skip_observability=True,
+            )
+            rows = payload.get("results", [])
+            return [
+                RetrievalCandidate(
+                    content_id=str(rows[0]["id"]),
+                    text=rows[0]["text"],
+                    metadata={
+                        "md": rows[0]["md"],
+                        "created_at": rows[0]["created_at"],
+                        "file_version_id": rows[0]["file_version_id"],
+                    },
+                    stage_scores={"bm25_score": float(rows[0]["bm25_score"])},
+                    stage_ranks={"bm25": 1},
+                    provenance=["bm25"],
+                )
+            ]
+
+    def _fake_build_retrievers_for_pipeline(*, search_file_chunks_fn=None, **kwargs):
+        return {"file_bm25": _TriggerRetriever(search_file_chunks_fn)}
+
+    monkeypatch.setattr(search_api, "_build_retrievers_for_pipeline", _fake_build_retrievers_for_pipeline)
+
+    async def _fake_run(self, **kwargs):
+        retriever = kwargs["retrievers"]["file_bm25"]
+        candidates = await retriever.retrieve(kwargs["request"])
+        return RetrievalExecutionResult(
+            pipeline_id="orchestrated.search_file_chunks",
+            pipeline_version="v1",
+            candidates=candidates,
+            traces=[RetrievalStageTrace(stage="retrieve:file_bm25", duration_ms=1.0)],
+            metadata={},
+        )
+
+    monkeypatch.setattr(search_api.PipelineOrchestrator, "run", _fake_run)
+    monkeypatch.setattr(search_api.metrics, "record_retrieval", lambda **kwargs: None)
+    monkeypatch.setattr(search_api, "log_retrieval_run", lambda *args, **kwargs: None)
+
+    result = original_search_file_chunks(
+        database=db,
+        auth={"username": "tester", "password_prehash": "x"},
+        query="compressor fault",
+        limit=5,
+        offset=0,
+    )
+
+    assert "results" in result and len(result["results"]) == 1
+    assert result["results"][0]["id"] == "fc_wrapped_1"

--- a/tests/test_retrieval_runs.py
+++ b/tests/test_retrieval_runs.py
@@ -484,3 +484,40 @@ def test_search_bm25_segment_requires_feature_flag(monkeypatch):
         assert False, "expected feature-flag assertion for segment retrieval"
     except AssertionError as exc:
         assert "segment retrieval is disabled" in str(exc)
+
+
+def test_search_file_chunks_wildcard_statement_uses_created_at_sort(monkeypatch):
+    class DummyDB:
+        pass
+
+    monkeypatch.setattr(search_api, "get_user", lambda database, auth: (SimpleNamespace(), SimpleNamespace(username="tester")))
+
+    statement = search_api.search_file_chunks(
+        database=DummyDB(),
+        auth={"username": "tester", "password_prehash": "x"},
+        query="*",
+        return_statement=True,
+    )
+
+    assert "ORDER BY created_at DESC" in statement
+    assert "paradedb.parse" not in statement
+    assert "WHERE f.created_by = 'tester'" in statement
+
+
+def test_search_file_chunks_wildcard_respects_explicit_sort(monkeypatch):
+    class DummyDB:
+        pass
+
+    monkeypatch.setattr(search_api, "get_user", lambda database, auth: (SimpleNamespace(), SimpleNamespace(username="tester")))
+
+    statement = search_api.search_file_chunks(
+        database=DummyDB(),
+        auth={"username": "tester", "password_prehash": "x"},
+        query="*",
+        sort_by="created_at",
+        sort_dir="ASC",
+        return_statement=True,
+    )
+
+    assert "ORDER BY created_at ASC" in statement
+    assert "paradedb.parse" not in statement


### PR DESCRIPTION
## Summary
- fix orchestrated file-chunk direct wrapper to avoid duplicate kwarg injection
- handle wildcard/empty file-chunk queries without BM25 parse requirement
- fallback wildcard score sorting to created_at when lexical score is unavailable
- ensure file records set created_by from resolved username path
- add regression tests for wildcard SQL generation and orchestrated direct-wrapper behavior

## Validation
- uv run pytest tests/test_retrieval_runs.py tests/test_retrieval_orchestrated_compat.py
- Result: 26 passed