### PR TITLE
Add legacy-name CI guard and symlink retirement runbook

### DIFF
--- a/.github/workflows/unification_checks.yml
+++ b/.github/workflows/unification_checks.yml
@@ -5,8 +5,12 @@ on:
     branches: ["main"]
   pull_request:
 
+concurrency:
+  group: unification-checks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  verify-pins:
+  verify-unification:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,5 +18,11 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v4
-      - name: Verify compat pins
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+            sdk/python/pyproject.toml
+      - name: Verify unification checks
         run: uv run --no-project bash scripts/ci_unification_checks.sh

--- a/README.md
+++ b/README.md
@@ -24,19 +24,9 @@ It is designed to be:
 | `server.py` | FastAPI + Ray Serve entrypoint |
 | `QueryLake/api/` | Core platform function APIs |
 | `QueryLake/runtime/` | Retrieval/runtime orchestration primitives |
-| `apps/studio/` | QueryLake Studio frontend (imported from `QueryLakeStudio`) |
 | `scripts/` | Eval, stress, rollout, and ops tooling |
 | `sdk/python/` | Standalone `querylake-sdk` Python package (PyPI target) |
 | `docs/` | Architecture, setup, SDK, release docs |
-
-## Repository topology and migration status
-
-- **Current canonical backend/runtime repo**: `kmccleary3301/QueryLake`
-- **Frontend repo rename**: `kmccleary3301/QueryLake` -> `kmccleary3301/QueryLakeStudio`
-- **Frontend development status**: `QueryLakeStudio` is deprecated as a standalone repo.
-- **Monorepo location for frontend code**: `apps/studio/` in this repository.
-
-Migration reference: `docs/unification/repo_migration.md`
 
 ## 5-minute local quickstart (API-only)
 
@@ -180,6 +170,7 @@ print(rows[:3])
 - Live staging integration contract: `docs/sdk/LIVE_STAGING_INTEGRATION.md`
 - SDK runnable examples: `examples/sdk/`
 - Route and unification docs: `docs/unification/`
+- Legacy-path retirement plan: `docs/unification/symlink_retirement_runbook.md`
 - Contributor guide: `CONTRIBUTING.md`
 
 ## Packaging and PyPI

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@
 - Program control and compatibility:
   - `docs/unification/program_control.md`
   - `docs/unification/compat_matrix.md`
+  - `docs/unification/symlink_retirement_runbook.md`
 
 ## Specialized docs
 

--- a/docs/unification/repo_pinning_playbook.md
+++ b/docs/unification/repo_pinning_playbook.md
@@ -20,3 +20,7 @@ Keep QueryLake, BreadBoard, and Hermes aligned without forcing a monorepo.
 - Fail CI if any pin is `<set>` or empty
 - Optional helper: `scripts/ci_unification_checks.sh`
 - GitHub Actions workflow: `.github/workflows/unification_checks.yml`
+
+## Related Migration Control
+- Legacy local-path alias retirement:
+  - `docs/unification/symlink_retirement_runbook.md`

--- a/docs/unification/symlink_retirement_runbook.md
+++ b/docs/unification/symlink_retirement_runbook.md
@@ -1,0 +1,74 @@
+# Legacy Path Symlink Retirement Runbook
+
+## Purpose
+
+Define a safe, explicit process to retire the legacy local path alias:
+
+- legacy alias: `/shared_folders/querylake_server/QueryLakeBackend`
+- canonical path: `/shared_folders/querylake_server/QueryLake`
+
+The goal is to finish repository naming unification without breaking local automation, CI scripts, or downstream repos that still depend on the legacy alias.
+
+## Current State
+
+- The legacy path is currently a symlink:
+  - `/shared_folders/querylake_server/QueryLakeBackend -> /shared_folders/querylake_server/QueryLake`
+- Canonical Git remote and project identity are already `QueryLake`.
+- Downstream CI guards were added in Breadboard and Hermes to block new legacy-name references in active branches.
+- QueryLake CI now enforces a legacy-name guard via:
+  - `scripts/ci_guard_legacy_querylakebackend_refs.sh`
+  - `scripts/ci_unification_checks.sh`
+  - `.github/workflows/unification_checks.yml`
+
+## Retirement Criteria (all required)
+
+1. **No active code references** to `QueryLakeBackend` in:
+   - QueryLake tracked source/docs/scripts (excluding `docs_tmp/` historical artifacts).
+   - Active branches in Breadboard and Hermes.
+2. **CI green** on unification checks for at least 7 consecutive days after criteria (1) is true.
+3. **Setup docs updated** so new users only see `QueryLake` canonical path examples.
+4. **Fallback tested**: recreate symlink in one command and validate startup/tests.
+
+## Timeline (relative to approval date `T0`)
+
+1. **T0 (approval + merge of this runbook)**
+   - Announce deprecation window in release notes / team channel.
+   - Mark alias as deprecated in setup docs.
+2. **T0 + 14 days**
+   - Enable strict CI guard in QueryLake for new legacy references (scoped to tracked code/docs, excluding `docs_tmp/`).
+   - Fix any remaining violations.
+3. **T0 + 30 days**
+   - Remove symlink from developer setup scripts and local bootstrap instructions.
+   - Keep manual rollback command documented.
+4. **T0 + 45 days (retirement cutover)**
+   - Remove symlink from shared environment hosts.
+   - Run smoke checks from canonical path only.
+
+## Execution Checklist
+
+1. Verify symlink status:
+   - `python -c "import os; print(os.path.islink('/shared_folders/querylake_server/QueryLakeBackend'))"`
+2. Scan for active legacy refs (exclude historical archives):
+   - `rg -n "QueryLakeBackend" --glob '!docs_tmp/**'`
+3. Validate CI:
+   - `make ci-unification`
+4. Remove symlink on cutover host:
+   - `rm /shared_folders/querylake_server/QueryLakeBackend`
+5. Validate canonical path flows:
+   - repo open, startup command, smoke tests, SDK docs examples.
+
+## Rollback (one-command restore)
+
+If any workflow still requires the alias after cutover:
+
+```bash
+ln -s /shared_folders/querylake_server/QueryLake /shared_folders/querylake_server/QueryLakeBackend
+```
+
+Then re-run the failing workflow and file a follow-up issue to remove the stale dependency.
+
+## Ownership
+
+- Owner: QueryLake maintainer (repo unification lead)
+- Review cadence: once per week until retirement cutover is complete
+- Artifact of record: this document + `docs/unification/compat_matrix.md`

--- a/docs/unification/unification_done_bar.md
+++ b/docs/unification/unification_done_bar.md
@@ -24,3 +24,5 @@
 - Model catalog endpoints (`/v1/models`, `/v1/models/{id}`) implemented in QueryLake.
 - Umbrella autoscaling knobs exposed via env vars and unit-tested.
 - CI guardrail workflow added for compat pins.
+- Legacy path alias retirement runbook documented:
+  - `docs/unification/symlink_retirement_runbook.md`

--- a/scripts/ci_guard_legacy_querylakebackend_refs.sh
+++ b/scripts/ci_guard_legacy_querylakebackend_refs.sh
@@ -1,28 +1,42 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
+# Block new usage of legacy repository/path naming in tracked files.
+# Historical archives under docs_tmp are intentionally excluded.
 
-# Historical migration documentation is allowed to mention the previous repo name.
-ALLOW_EXCLUDES=(
-  ":(exclude)docs/unification/repo_migration.md"
-  ":(exclude)scripts/ci_guard_legacy_querylakebackend_refs.sh"
+pattern="QueryLakeBackend"
+
+# Allowed references:
+# - retirement runbook documents the legacy alias explicitly.
+# - repo migration doc captures historical rename details.
+# - this guard script contains the pattern literal by design.
+allowlist=(
+  "docs/unification/symlink_retirement_runbook.md"
+  "docs/unification/repo_migration.md"
+  "scripts/ci_guard_legacy_querylakebackend_refs.sh"
 )
 
-PATTERN='QueryLakeBackend|/shared_folders/querylake_server/QueryLakeBackend'
+pathspec=( "." ":(exclude)docs_tmp/**" )
+for allowed in "${allowlist[@]}"; do
+  pathspec+=( ":(exclude)${allowed}" )
+done
 
-if MATCHES="$(git grep -n -I -E "$PATTERN" -- . "${ALLOW_EXCLUDES[@]}" || true)"; then
-  :
-fi
+set +e
+matches="$(git grep -n "${pattern}" -- "${pathspec[@]}")"
+status=$?
+set -e
 
-if [[ -n "${MATCHES// }" ]]; then
-  echo "ERROR: Legacy QueryLakeBackend reference(s) detected."
-  echo "Please migrate to the canonical QueryLake naming."
+if [[ ${status} -eq 0 ]]; then
+  echo "Legacy naming guard failed: found '${pattern}' references outside allowlist."
   echo
-  echo "$MATCHES"
+  echo "${matches}"
   exit 1
 fi
 
-echo "Legacy path/name guard passed."
+if [[ ${status} -eq 1 ]]; then
+  echo "Legacy naming guard passed: no disallowed '${pattern}' references found."
+  exit 0
+fi
 
+echo "Legacy naming guard error: git grep exited with status ${status}."
+exit ${status}

--- a/scripts/ci_unification_checks.sh
+++ b/scripts/ci_unification_checks.sh
@@ -2,3 +2,4 @@
 set -euo pipefail
 
 python scripts/verify_compat_pins.py
+bash scripts/ci_guard_legacy_querylakebackend_refs.sh


### PR DESCRIPTION
## Summary
- add a QueryLake-side legacy naming guard that fails CI on disallowed `QueryLakeBackend` references
- wire the guard into the existing unification check script
- broaden unification workflow triggers so the guard runs on all PR/push changes
- add and cross-link a concrete symlink retirement runbook

## Changes
- new guard script: `scripts/ci_guard_legacy_querylakebackend_refs.sh`
  - scans tracked files for `QueryLakeBackend`
  - excludes `docs_tmp/**`
  - allowlists historical migration docs and the retirement runbook
- updated `scripts/ci_unification_checks.sh` to run:
  - `scripts/verify_compat_pins.py`
  - `scripts/ci_guard_legacy_querylakebackend_refs.sh`
- updated `.github/workflows/unification_checks.yml`
  - run on all PR/pushes to `main` (no narrow path filter)
  - job now validates full unification checks
- added runbook:
  - `docs/unification/symlink_retirement_runbook.md`
- linked runbook from docs index files

## Validation
- `make ci-unification`
  - `All pins set.`
  - `Legacy naming guard passed: no disallowed 'QueryLakeBackend' references found.`
