### PR TITLE
Restore README repository topology section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ It is designed to be:
 | `sdk/python/` | Standalone `querylake-sdk` Python package (PyPI target) |
 | `docs/` | Architecture, setup, SDK, release docs |
 
+## Repository topology and migration status
+
+- **Current canonical backend/runtime repo**: `kmccleary3301/QueryLake`
+- **Frontend repo rename**: `kmccleary3301/QueryLake` -> `kmccleary3301/QueryLakeStudio`
+- **Frontend development status**: `QueryLakeStudio` is deprecated as a standalone repo.
+- **Monorepo location for frontend code**: `apps/studio/` in this repository.
+
+Migration reference: `docs/unification/repo_migration.md`
+
 ## 5-minute local quickstart (API-only)
 
 API-only mode is the fastest setup for developers and RAG researchers.


### PR DESCRIPTION
## Summary
Restore the `Repository topology and migration status` section that was unintentionally removed from `README.md` in the prior unification guard PR.

## Validation
- Docs-only restoration; no code path changes.
