### PR TITLE
Deprecate legacy local alias in setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Migration reference: `docs/unification/repo_migration.md`
 ## 5-minute local quickstart (API-only)
 
 API-only mode is the fastest setup for developers and RAG researchers.
+Use the canonical repository path `QueryLake`; the old backend-named local alias is deprecated and only exists temporarily as a compatibility symlink during the retirement window in `docs/unification/symlink_retirement_runbook.md`.
 
 ### 1) Bootstrap environment
 

--- a/docs/setup/DEVELOPER_SETUP.md
+++ b/docs/setup/DEVELOPER_SETUP.md
@@ -10,6 +10,9 @@ This setup path is optimized for backend contributors and RAG researchers.
 
 ## 1) Clone and bootstrap
 
+Use the canonical local directory name `QueryLake`.
+The old backend-named local alias is deprecated and is only retained temporarily as a compatibility symlink during the retirement window documented in `docs/unification/symlink_retirement_runbook.md`.
+
 ```bash
 git clone <repo-url>
 cd QueryLake

--- a/docs/unification/repo_migration.md
+++ b/docs/unification/repo_migration.md
@@ -60,3 +60,12 @@ git subtree add --prefix=apps/studio studio/master -m "monorepo: import QueryLak
 
 - `QueryLake`: canonical monorepo (backend + SDK + studio at `apps/studio`)
 - `QueryLakeStudio`: deprecated archive/deprecation pointer
+
+## Local path transition status
+
+- Canonical local path:
+  - `/shared_folders/querylake_server/QueryLake`
+- Deprecated compatibility alias:
+  - `/shared_folders/querylake_server/QueryLakeBackend`
+- Retirement policy:
+  - `docs/unification/symlink_retirement_runbook.md`


### PR DESCRIPTION
## Summary

Complete the immediate `T0` documentation task from the symlink retirement runbook by marking the old backend-named local alias as deprecated in setup-facing docs.

## Changes

- add canonical-path guidance to `README.md`
- add canonical-path guidance to `docs/setup/DEVELOPER_SETUP.md`
- record local path transition state in `docs/unification/repo_migration.md`

## Validation

- `make ci-docs`
- `make ci-unification`
